### PR TITLE
Feature/front/problemList

### DIFF
--- a/backend/lambdas/community-lambda-functions/comment/createComment_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/comment/createComment_modified.mjs
@@ -51,7 +51,8 @@ export const handler = async (event) => {
       };
     }
 
-    const author = claims["cognito:username"];
+    const author = claims["given_name"] || claims["cognito:username"] || "익명";
+    const userId = claims.sub;
     const commentId = uuidv4();
     const createdAt = new Date().toISOString();
 
@@ -67,6 +68,7 @@ export const handler = async (event) => {
               SK: `COMMENT#${commentId}`,
               commentId,
               author,
+              userId,
               content,
               createdAt,
               // Add GSI keys if comments need separate listing/sorting later
@@ -97,6 +99,7 @@ export const handler = async (event) => {
       postId,
       commentId,
       author,
+      userId,
       content,
       createdAt,
     };

--- a/backend/lambdas/community-lambda-functions/comment/getComments_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/comment/getComments_modified.mjs
@@ -39,7 +39,7 @@ export const handler = async (event) => {
         ":commentPrefix": "COMMENT#",
       },
       // Select only needed attributes to reduce payload size
-      ProjectionExpression: "commentId, content, author, createdAt, SK",
+      ProjectionExpression: "commentId, content, author, createdAt, SK, userId",
       ScanIndexForward: false, // Get latest comments first (descending sort key order)
     };
 
@@ -50,12 +50,13 @@ export const handler = async (event) => {
 
     // Map results using logic from community/getComments.js
     const comments = items.map(
-      ({ content, author, createdAt, SK, commentId }) => ({
+      ({ content, author, createdAt, SK, commentId, userId }) => ({
         // Prefer using the dedicated commentId attribute if available, otherwise parse SK
         commentId: commentId || SK.replace("COMMENT#", ""),
         content,
         author,
         createdAt,
+        userId, // Include userId for author verification
       })
     );
 

--- a/backend/lambdas/community-lambda-functions/createPost_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/createPost_modified.mjs
@@ -50,7 +50,7 @@ export const handler = async (event) => {
       };
     }
 
-    const author = claims["cognito:username"];
+    const author = claims["given_name"] || claims["cognito:username"] || "익명";
     const userId = claims.sub; // Use 'sub' from JWT as userId
     const postId = uuidv4();
     const createdAt = new Date().toISOString();

--- a/backend/lambdas/community-lambda-functions/deletePost_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/deletePost_modified.mjs
@@ -36,7 +36,7 @@ export const handler = async (event) => {
 
     // Get user info from API Gateway JWT Authorizer
     const claims = event.requestContext?.authorizer?.claims;
-    if (!claims || !claims["cognito:username"]) {
+    if (!claims || !claims.sub) {
       console.warn("❌ Missing or invalid claims:", claims);
       return {
         statusCode: 401,
@@ -44,7 +44,7 @@ export const handler = async (event) => {
         body: JSON.stringify({ message: "인증 정보가 없습니다." }),
       };
     }
-    const username = claims["cognito:username"];
+    const userId = claims.sub;
 
     // --- Get Post and Verify Ownership using SDK v3 style ---
     const getCommand = new GetCommand({
@@ -62,7 +62,7 @@ export const handler = async (event) => {
       };
     }
 
-    if (post.author !== username) {
+    if (post.userId !== userId) {
       return {
         statusCode: 403, // Forbidden
         headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/backend/lambdas/community-lambda-functions/getAllPosts_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/getAllPosts_modified.mjs
@@ -53,6 +53,7 @@ export const handler = async (event) => {
       postId: item.PK, // PK is the postId
       title: item.title,
       author: item.author,
+      userId: item.userId,
       createdAt: item.createdAt,
       likesCount: item.likesCount ?? 0, // Use nullish coalescing for default
       commentCount: item.commentCount ?? 0, // Use nullish coalescing for default

--- a/backend/lambdas/community-lambda-functions/getPost_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/getPost_modified.mjs
@@ -62,7 +62,7 @@ export const handler = async (event) => {
       updatedAt = null,
       problemId = null,
       // Include userId if it's stored and might be needed
-      // userId
+      userId,
     } = post;
 
     // --- SUCCESS RESPONSE ---
@@ -76,7 +76,7 @@ export const handler = async (event) => {
       likedUsers: Array.isArray(likedUsers) ? likedUsers : [], // Ensure it's an array
       updatedAt,
       problemId,
-      // userId
+      userId,
     };
     return {
       statusCode: 200,

--- a/backend/lambdas/community-lambda-functions/updatePost_modified.mjs
+++ b/backend/lambdas/community-lambda-functions/updatePost_modified.mjs
@@ -52,7 +52,8 @@ export const handler = async (event) => {
         body: JSON.stringify({ message: "인증 정보가 없습니다." }),
       };
     }
-    const username = claims["cognito:username"];
+
+    const userId = claims.sub;
 
     // --- Check Post Existence and Ownership using SDK v3 style ---
     // We use a ConditionExpression in the UpdateCommand instead of a separate Get
@@ -65,12 +66,12 @@ export const handler = async (event) => {
       UpdateExpression:
         "SET title = :title, content = :content, updatedAt = :updatedAt",
       // Condition ensures the post exists AND the author matches
-      ConditionExpression: "attribute_exists(PK) AND author = :author",
+      ConditionExpression: "attribute_exists(PK) AND userId = :userId",
       ExpressionAttributeValues: {
         ":title": title,
         ":content": content,
         ":updatedAt": new Date().toISOString(),
-        ":author": username, // Value for the condition check
+        ":userId": userId,
       },
       ReturnValues: "ALL_NEW", // Return the entire updated item
     });

--- a/backend/lambdas/problem-generator-v2/index.mjs
+++ b/backend/lambdas/problem-generator-v2/index.mjs
@@ -492,6 +492,7 @@ export const handler = awslambda.streamifyResponse(
 
       const userPrompt = body.prompt || "";
       const difficulty = body.difficulty || "Medium"; // Default difficulty
+      const creatorId = body.creatorId || ""; // Extract creatorId from request
 
       if (!userPrompt) {
         throw new Error(
@@ -513,6 +514,7 @@ export const handler = awslambda.streamifyResponse(
         generationStatus: "started",
         createdAt: createdAt,
         language: DEFAULT_LANGUAGE, // Use constant or make configurable
+        creatorId: creatorId, // Add creatorId to the initial item
       };
 
       try {
@@ -998,6 +1000,7 @@ export const handler = awslambda.streamifyResponse(
         description_translated: translatedDescription, // Translated description
         targetLanguage: targetLanguage, // Language used for translation
         completedAt: completedAt,
+        creatorId: creatorId, // Ensure creatorId is in the final updates
         // Other fields were saved in previous steps
       };
       await updateDynamoDbStatus(problemId, finalUpdates);
@@ -1032,6 +1035,7 @@ export const handler = awslambda.streamifyResponse(
         targetLanguage: targetLanguage, // Language used
         generationStatus: "completed",
         completedAt: completedAt,
+        creatorId: creatorId, // Include creatorId in the final problem data
       };
 
       sendSse(stream, "result", {

--- a/backend/lambdas/problem-generator-v2/index.mjs
+++ b/backend/lambdas/problem-generator-v2/index.mjs
@@ -493,6 +493,7 @@ export const handler = awslambda.streamifyResponse(
       const userPrompt = body.prompt || "";
       const difficulty = body.difficulty || "Medium"; // Default difficulty
       const creatorId = body.creatorId || ""; // Extract creatorId from request
+      const author = body.author || ""; // Extract author from request
 
       if (!userPrompt) {
         throw new Error(
@@ -515,6 +516,7 @@ export const handler = awslambda.streamifyResponse(
         createdAt: createdAt,
         language: DEFAULT_LANGUAGE, // Use constant or make configurable
         creatorId: creatorId, // Add creatorId to the initial item
+        author: author, // Add author to the initial item
       };
 
       try {
@@ -1001,6 +1003,7 @@ export const handler = awslambda.streamifyResponse(
         targetLanguage: targetLanguage, // Language used for translation
         completedAt: completedAt,
         creatorId: creatorId, // Ensure creatorId is in the final updates
+        author: author, // Add author to the final updates
         // Other fields were saved in previous steps
       };
       await updateDynamoDbStatus(problemId, finalUpdates);
@@ -1036,6 +1039,7 @@ export const handler = awslambda.streamifyResponse(
         generationStatus: "completed",
         completedAt: completedAt,
         creatorId: creatorId, // Include creatorId in the final problem data
+        author: author, // Include author in the final problem data
       };
 
       sendSse(stream, "result", {

--- a/backend/lambdas/problems-api/getAllProblems.mjs
+++ b/backend/lambdas/problems-api/getAllProblems.mjs
@@ -54,7 +54,7 @@ export const handler = async (event) => {
           ":creatorId": creatorId,
         },
         ProjectionExpression:
-          "problemId, title, difficulty, algorithmType, createdAt, creatorId",
+          "problemId, title, difficulty, algorithmType, createdAt, creatorId, author",
       };
 
       console.log("Querying by creatorId:", queryParams);
@@ -67,7 +67,7 @@ export const handler = async (event) => {
       const scanParams = {
         TableName: tableName,
         ProjectionExpression:
-          "problemId, title, difficulty, algorithmType, createdAt, creatorId",
+          "problemId, title, difficulty, algorithmType, createdAt, creatorId, author",
       };
 
       console.log("Scanning all problems");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.13",
         "aws-amplify": "^6.9.5",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.6.5",
         "next": "^15.2.4",
         "react": "^19.0.0",
@@ -4829,6 +4830,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "aws-amplify": "^6.9.5",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.6.5",
     "next": "^15.2.4",
     "react": "^19.0.0",

--- a/frontend/src/api/communityApi.ts
+++ b/frontend/src/api/communityApi.ts
@@ -24,6 +24,7 @@ export interface PostDetail {
   title: string;
   content: string;
   author: string;
+  userId: string;
   createdAt: string;
   updatedAt?: string | null;
   likesCount: number;
@@ -37,6 +38,7 @@ export interface Comment {
   commentId: string;
   content: string;
   author: string;
+  userId: string;
   createdAt: string;
 }
 

--- a/frontend/src/api/generateProblemApi.ts
+++ b/frontend/src/api/generateProblemApi.ts
@@ -40,6 +40,7 @@ export type ProblemDifficulty = "튜토리얼" | "쉬움" | "보통" | "어려�
 export interface CreateProblemRequest {
   prompt: string;
   difficulty: ProblemDifficulty;
+  creatorId?: string; // Add optional creatorId field
 }
 
 export interface CreateProblemResponse {

--- a/frontend/src/api/generateProblemApi.ts
+++ b/frontend/src/api/generateProblemApi.ts
@@ -41,6 +41,7 @@ export interface CreateProblemRequest {
   prompt: string;
   difficulty: ProblemDifficulty;
   creatorId?: string; // Add optional creatorId field
+  author?: string; // Add optional author field
 }
 
 export interface CreateProblemResponse {

--- a/frontend/src/api/problemApi.ts
+++ b/frontend/src/api/problemApi.ts
@@ -19,6 +19,7 @@ export interface ProblemSummary {
   algorithmType?: string; // 선택적 필드
   createdAt: string;
   creatorId?: string; // Add creatorId field
+  author?: string; // Add author field
 }
 
 /**

--- a/frontend/src/api/problemApi.ts
+++ b/frontend/src/api/problemApi.ts
@@ -18,6 +18,7 @@ export interface ProblemSummary {
   difficulty: string; // 예: "Easy", "Medium", "Hard" 또는 생성된 값 그대로
   algorithmType?: string; // 선택적 필드
   createdAt: string;
+  creatorId?: string; // Add creatorId field
 }
 
 /**
@@ -131,12 +132,16 @@ const handleApiResponse = async (response: Response): Promise<unknown> => {
 // --- API Functions ---
 
 /**
- * 모든 문제의 요약 목록을 가져옵니다.
- * GET /problems
+ * 모든 문제의 요약 목록을 가져옵니다. creatorId를 지정하면 특정 유저가 만든 문제만 가져옵니다.
+ * GET /problems or GET /problems?creatorId={creatorId}
  * (인증 불필요)
  */
-export const getProblems = async (): Promise<ProblemSummary[]> => {
-  const response = await fetch(`${API_BASE_URL}/problems`, {
+export const getProblems = async (creatorId?: string): Promise<ProblemSummary[]> => {
+  const url = creatorId
+    ? `${API_BASE_URL}/problems?creatorId=${encodeURIComponent(creatorId)}`
+    : `${API_BASE_URL}/problems`;
+    
+  const response = await fetch(url, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -186,6 +191,8 @@ export const getProblemById = async (
   console.log(response);
   return handleApiResponse(response) as Promise<ProblemDetail>;
 };
+
+
 
 // TODO: Add functions for other problem-related endpoints if they are created later
 // e.g., creating problems manually (POST /problems - requires auth)

--- a/frontend/src/app/coding-test/page.tsx
+++ b/frontend/src/app/coding-test/page.tsx
@@ -69,7 +69,8 @@ const CodingTestPage: React.FC = () => {
     (problem) =>
       problem.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       problem.algorithmType?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      problem.creatorId?.toLowerCase().includes(searchTerm.toLowerCase()) // Also allow filtering by creator
+      // problem.creatorId?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      problem.author?.toLowerCase().includes(searchTerm.toLowerCase()) // Also allow filtering by author
   );
 
   // --- Sorting logic ---
@@ -79,7 +80,8 @@ const CodingTestPage: React.FC = () => {
         case "title": return a.title || "";
         case "algorithmType": return a.algorithmType || "기타";
         case "difficulty": return a.difficulty || "";
-        case "creatorId": return a.creatorId || "Unknown"; // Handle missing creatorId
+        // case "creatorId": return a.creatorId || "Unknown"; // Handle missing creatorId
+        case "author": return a.author || "Unknown"; // Handle missing author
         case "createdAt": return a.createdAt || "";
         default: return "";
       }
@@ -90,7 +92,8 @@ const CodingTestPage: React.FC = () => {
         case "title": return b.title || "";
         case "algorithmType": return b.algorithmType || "기타";
         case "difficulty": return b.difficulty || "";
-        case "creatorId": return b.creatorId || "Unknown";
+        // case "creatorId": return b.creatorId || "Unknown";
+        case "author": return b.author || "Unknown";
         case "createdAt": return b.createdAt || "";
         default: return "";
       }
@@ -260,18 +263,15 @@ const CodingTestPage: React.FC = () => {
                           </th>
                            <th
                             className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 hidden md:table-cell" // Hide on small screens
-                            onClick={() => handleSort("creatorId")}
+                            onClick={() => handleSort("author")}
                           >
-                            생성자 {renderSortIndicator("creatorId")}
+                            생성자 {renderSortIndicator("author")}
                           </th>
                           <th
                             className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 hidden sm:table-cell" // Hide on very small screens
                             onClick={() => handleSort("createdAt")}
                           >
                             생성 날짜 {renderSortIndicator("createdAt")}
-                          </th>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                            Action
                           </th>
                         </tr>
                       </thead>
@@ -300,20 +300,12 @@ const CodingTestPage: React.FC = () => {
                               </span>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell">
-                              {problem.creatorId || "Unknown"}
+                              {problem.author || "Unknown"}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap hidden sm:table-cell">
                               <div className="text-sm text-gray-500">
                                 {formatDate(problem.createdAt)}
                               </div>
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
-                              <Link
-                                href={`/coding-test/solve?id=${problem.problemId}`}
-                                className="inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-primary-hover bg-primary/10 hover:bg-primary/20 transition"
-                              >
-                                풀기
-                              </Link>
                             </td>
                           </tr>
                         ))}

--- a/frontend/src/app/coding-test/page.tsx
+++ b/frontend/src/app/coding-test/page.tsx
@@ -1,10 +1,139 @@
-import React from "react";
+"use client"; // Needs to be a client component for state and effects
+import React, { useState, useEffect } from "react"; // Import hooks
 import Head from "next/head";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Link from "next/link";
+import { getProblems, ProblemSummary } from "@/api/problemApi"; // Import API function and type
+import { format } from "date-fns"; // Import date formatting utility
+
+// Format the date from ISO string (same as storage page)
+const formatDate = (dateStr: string) => {
+  try {
+    return format(new Date(dateStr), "yyyy-MM-dd HH:mm");
+  } catch {
+    return dateStr; // Fallback
+  }
+};
+
+// Difficulty badge styling function (can be shared or defined here)
+const getDifficultyClass = (difficulty: string) => {
+  switch (difficulty?.toLowerCase()) {
+    case "easy":
+    case "쉬움":
+      return "bg-green-100 text-green-800";
+    case "medium":
+    case "보통":
+      return "bg-yellow-100 text-yellow-800";
+    case "hard":
+    case "어려움":
+      return "bg-red-100 text-red-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
 
 const CodingTestPage: React.FC = () => {
+  // --- State for the problem list ---
+  const [searchTerm, setSearchTerm] = useState("");
+  const [allProblems, setAllProblems] = useState<ProblemSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortColumn, setSortColumn] = useState<string>("createdAt"); // Default sort by creation date
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc"); // Default newest first
+
+  // --- Fetch all problems ---
+  useEffect(() => {
+    const fetchAllProblems = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        // Fetch all problems (no creatorId passed)
+        const problems = await getProblems();
+        setAllProblems(problems);
+      } catch (err) {
+        console.error("Error fetching all problems:", err);
+        setError(
+          err instanceof Error ? err.message : "전체 문제를 불러오는 데 실패했습니다."
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAllProblems();
+  }, []); // Empty dependency array means run once on mount
+
+  // --- Filtering logic ---
+  const filteredProblems = allProblems.filter(
+    (problem) =>
+      problem.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      problem.algorithmType?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      problem.creatorId?.toLowerCase().includes(searchTerm.toLowerCase()) // Also allow filtering by creator
+  );
+
+  // --- Sorting logic ---
+  const sortedProblems = [...filteredProblems].sort((a, b) => {
+    const getValueA = () => {
+      switch (sortColumn) {
+        case "title": return a.title || "";
+        case "algorithmType": return a.algorithmType || "기타";
+        case "difficulty": return a.difficulty || "";
+        case "creatorId": return a.creatorId || "Unknown"; // Handle missing creatorId
+        case "createdAt": return a.createdAt || "";
+        default: return "";
+      }
+    };
+
+    const getValueB = () => {
+       switch (sortColumn) {
+        case "title": return b.title || "";
+        case "algorithmType": return b.algorithmType || "기타";
+        case "difficulty": return b.difficulty || "";
+        case "creatorId": return b.creatorId || "Unknown";
+        case "createdAt": return b.createdAt || "";
+        default: return "";
+      }
+    };
+
+    const valueA = getValueA();
+    const valueB = getValueB();
+
+    // Specific handling for difficulty
+    if (sortColumn === "difficulty") {
+      const difficultyOrder = { 쉬움: 1, Easy: 1, 보통: 2, Medium: 2, 어려움: 3, Hard: 3 };
+      const orderA = difficultyOrder[valueA as keyof typeof difficultyOrder] || 0;
+      const orderB = difficultyOrder[valueB as keyof typeof difficultyOrder] || 0;
+      return sortDirection === "asc" ? orderA - orderB : orderB - orderA;
+    }
+
+    // Default string comparison for other columns
+    if (sortDirection === "asc") {
+      return valueA.localeCompare(valueB);
+    } else {
+      return valueB.localeCompare(valueA);
+    }
+  });
+
+  // --- Sort handling functions ---
+  const handleSort = (column: string) => {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc"); // Default to ascending for new column
+    }
+  };
+
+  const renderSortIndicator = (column: string) => {
+    if (sortColumn !== column) return null;
+    return (
+      <span className="ml-1 text-xs inline-block">
+        {sortDirection === "asc" ? "▲" : "▼"}
+      </span>
+    );
+  };
+
   return (
     <>
       <Head>
@@ -15,6 +144,7 @@ const CodingTestPage: React.FC = () => {
         <Header />
 
         <main className="flex-grow">
+          {/* --- Existing Top Section --- */}
           <div className="max-w-5xl mx-auto p-8">
             <div className="flex justify-between items-center mb-8">
               <h1 className="text-3xl font-bold text-gray-900">코딩 테스트</h1>
@@ -40,7 +170,7 @@ const CodingTestPage: React.FC = () => {
               </Link>
             </div>
 
-            <div className="bg-white rounded-lg shadow-sm p-8 text-center">
+            <div className="bg-white rounded-lg shadow-sm p-8 text-center mb-12"> {/* Added mb-12 */}
               <h2 className="text-2xl font-semibold text-gray-900 mb-4">
                 원하는 테스트 유형을 선택하세요
               </h2>
@@ -57,13 +187,157 @@ const CodingTestPage: React.FC = () => {
                 </Link>
                 <Link
                   href="/generate-problem"
-                  className="inline-block px-6 py-3 bg-gray-600 text-white font-medium rounded-md hover:bg-gray-700 transition" // Changed background color for better visibility
+                  className="inline-block px-6 py-3 bg-gray-600 text-white font-medium rounded-md hover:bg-gray-700 transition"
                 >
                   AI로 문제 생성하기 🤖
                 </Link>
               </div>
             </div>
-          </div>
+
+            {/* --- New Problem List Section --- */}
+            <div className="mb-8"> {/* Wrapper for the list section */}
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4">
+                 <h2 className="text-2xl font-semibold text-gray-900 mb-4 sm:mb-0">
+                    전체 문제 목록
+                 </h2>
+                 <div className="relative w-full sm:w-64">
+                   <input
+                     type="text"
+                     placeholder="제목, 유형, 생성자 검색..."
+                     value={searchTerm}
+                     onChange={(e) => setSearchTerm(e.target.value)}
+                     className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary w-full text-sm"
+                   />
+                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-400">
+                     <svg
+                       viewBox="0 0 20 20"
+                       fill="currentColor"
+                       className="h-5 w-5"
+                     >
+                       <path
+                         fillRule="evenodd"
+                         d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                         clipRule="evenodd"
+                       />
+                     </svg>
+                   </div>
+                 </div>
+               </div>
+
+
+              <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+                {loading ? (
+                  <div className="py-10 px-6 text-center">
+                    <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+                    <p className="mt-2 text-gray-500">문제 목록을 불러오는 중...</p>
+                  </div>
+                ) : error ? (
+                  <div className="py-10 px-6 text-center">
+                    <p className="text-red-500">{error}</p>
+                  </div>
+                ) : sortedProblems.length > 0 ? (
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort("title")}
+                          >
+                            제목 {renderSortIndicator("title")}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort("algorithmType")}
+                          >
+                            알고리즘 유형 {renderSortIndicator("algorithmType")}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort("difficulty")}
+                          >
+                            난이도 {renderSortIndicator("difficulty")}
+                          </th>
+                           <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 hidden md:table-cell" // Hide on small screens
+                            onClick={() => handleSort("creatorId")}
+                          >
+                            생성자 {renderSortIndicator("creatorId")}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 hidden sm:table-cell" // Hide on very small screens
+                            onClick={() => handleSort("createdAt")}
+                          >
+                            생성 날짜 {renderSortIndicator("createdAt")}
+                          </th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Action
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="bg-white divide-y divide-gray-200">
+                        {sortedProblems.map((problem) => (
+                          <tr 
+                            key={problem.problemId} 
+                            className="hover:bg-gray-50 cursor-pointer"
+                            onClick={() => window.location.href = `/coding-test/solve?id=${problem.problemId}`}
+                          >
+                            <td className="px-6 py-4 whitespace-nowrap">
+                              <div className="text-sm font-medium text-gray-900 truncate max-w-xs">
+                                {problem.title}
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap">
+                              <div className="text-sm text-gray-500">
+                                {problem.algorithmType || "기타"}
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap">
+                              <span
+                                className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getDifficultyClass(problem.difficulty)}`}
+                              >
+                                {problem.difficulty}
+                              </span>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell">
+                              {problem.creatorId || "Unknown"}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap hidden sm:table-cell">
+                              <div className="text-sm text-gray-500">
+                                {formatDate(problem.createdAt)}
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
+                              <Link
+                                href={`/coding-test/solve?id=${problem.problemId}`}
+                                className="inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-primary-hover bg-primary/10 hover:bg-primary/20 transition"
+                              >
+                                풀기
+                              </Link>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="py-10 px-6 text-center">
+                    <p className="text-gray-500">
+                      {searchTerm ? "검색 결과가 없습니다." : "등록된 문제가 없습니다."}
+                    </p>
+                     {!searchTerm && ( // Show generate button only if no problems and not searching
+                        <Link
+                            href="/generate-problem"
+                            className="mt-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-hover transition"
+                        >
+                            문제 생성하기
+                        </Link>
+                     )}
+                  </div>
+                )}
+              </div>
+            </div> {/* End Problem List Section Wrapper */}
+          </div> {/* End max-w-5xl container */}
         </main>
 
         <Footer />

--- a/frontend/src/app/generate-problem/GenerateProblemClient.tsx
+++ b/frontend/src/app/generate-problem/GenerateProblemClient.tsx
@@ -221,12 +221,14 @@ const GenerateProblemClient = () => {
       try {
         const session = await fetchAuthSession();
         const idToken = session.tokens?.idToken;
-        const username = (idToken?.payload?.["cognito:username"] as string) || undefined;
-        console.log("creatorId:", username);
+        const creatorId = idToken?.payload?.sub as string;
+        const username = (idToken?.payload?.["given_name"] as string) || undefined;
+        console.log("generate-problem creatorId:", creatorId);
         const params: CreateProblemRequest = {
           prompt: currentPrompt,
           difficulty: difficultyMap[difficulty],
-          creatorId: username, // Add creator ID if available
+          creatorId: creatorId, // Add creator ID if available
+          author: username, // Add author if available
         };
 
         try {

--- a/frontend/src/app/storage/page.tsx
+++ b/frontend/src/app/storage/page.tsx
@@ -33,14 +33,14 @@ const StoragePage: React.FC = () => {
         
         // Get user ID from token
         const session = await fetchAuthSession();
-        const username = session.tokens?.idToken?.payload?.["cognito:username"] as string;
+        const creatorId = session.tokens?.idToken?.payload?.sub as string;
         
-        if (!username) {
+        if (!creatorId) {
           throw new Error("사용자 정보를 가져올 수 없습니다.");
         }
         
         // Fetch problems created by this user
-        const problems = await getProblems(username);
+        const problems = await getProblems(creatorId);
         setUserProblems(problems);
       } catch (err) {
         console.error("Error fetching user problems:", err);
@@ -263,14 +263,15 @@ const StoragePage: React.FC = () => {
                         >
                           생성 날짜 {renderSortIndicator("createdAt")}
                         </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          작업
-                        </th>
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
                       {sortedProblems.map((problem) => (
-                        <tr key={problem.problemId} className="hover:bg-gray-50">
+                        <tr 
+                          key={problem.problemId} 
+                          className="hover:bg-gray-50 cursor-pointer"
+                          onClick={() => window.location.href = `/coding-test/solve?id=${problem.problemId}`}
+                        >
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="text-sm font-medium text-gray-900">
                               {problem.title}
@@ -298,25 +299,6 @@ const StoragePage: React.FC = () => {
                             <div className="text-sm text-gray-500">
                               {formatDate(problem.createdAt)}
                             </div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <Link
-                              href={`/coding-test/solve?id=${problem.problemId}`}
-                              className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-primary-hover bg-primary/10 hover:bg-primary/20 transition"
-                            >
-                              <svg
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                                className="h-4 w-4 mr-1"
-                              >
-                                <path
-                                  fillRule="evenodd"
-                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z"
-                                  clipRule="evenodd"
-                                />
-                              </svg>
-                              문제 풀기
-                            </Link>
                           </td>
                         </tr>
                       ))}

--- a/frontend/src/components/community/CommunityDetail.tsx
+++ b/frontend/src/components/community/CommunityDetail.tsx
@@ -28,7 +28,8 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
     context.authStatus,
   ]);
   const isAuthenticated = authStatus === "authenticated";
-  const currentUsername = user?.username; // Or use signInDetails?.loginId depending on config
+  console.log("user:", user);
+  const currentUserId = user?.userId; // Or use signInDetails?.loginId depending on config
 
   const [post, setPost] = useState<PostDetail | null>(null);
   const [comments, setComments] = useState<Comment[]>([]);
@@ -69,8 +70,8 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
         setLikeCount(postResult.value.likesCount ?? 0);
         // Check if current user liked this post
         setIsLiked(
-          !!currentUsername &&
-            postResult.value.likedUsers?.includes(currentUsername)
+          !!currentUserId &&
+            postResult.value.likedUsers?.includes(currentUserId)
         );
       } else {
         console.error("Failed to fetch post:", postResult.reason);
@@ -107,7 +108,7 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
       setIsLoadingPost(false);
       setIsLoadingComments(false);
     }
-  }, [id, currentUsername, errorPost, errorComments]); // Add dependencies
+  }, [id, currentUserId, errorPost, errorComments]); // Add dependencies
 
   useEffect(() => {
     if (id) {
@@ -178,7 +179,7 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
 
   // Handle Post Deletion
   const handleDeletePost = async () => {
-    if (!isAuthenticated || !post || post.author !== currentUsername) {
+    if (!isAuthenticated || !post || post.userId !== currentUserId) {
       toast.error("게시글을 삭제할 권한이 없습니다.");
       return;
     }
@@ -207,7 +208,7 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
     if (
       !isAuthenticated ||
       !commentToDelete ||
-      commentToDelete.author !== currentUsername
+      commentToDelete.userId !== currentUserId
     ) {
       toast.error("댓글을 삭제할 권한이 없습니다.");
       return;
@@ -272,7 +273,7 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
     );
   }
 
-  const isAuthor = isAuthenticated && post.author === currentUsername;
+  const isAuthor = isAuthenticated && post.userId === currentUserId;
 
   return (
     <div className="max-w-5xl mx-auto p-8">
@@ -399,7 +400,7 @@ const CommunityDetail: React.FC<CommunityDetailProps> = ({ id }) => {
                       </div>
                       {/* Delete Button for Comment Author */}
                       {isAuthenticated &&
-                        comment.author === currentUsername && (
+                        comment.userId === currentUserId && (
                           <button
                             onClick={() =>
                               handleDeleteComment(comment.commentId)

--- a/infrastructure/api/dynamodb.tf
+++ b/infrastructure/api/dynamodb.tf
@@ -40,7 +40,8 @@ resource "aws_dynamodb_table" "community_table" {
       "createdAt",
       "likesCount",
       "commentCount",
-      "problemId"
+      "problemId",
+      "userId"
       # createdAt is the range key (GSI1SK), so it's automatically included
       # PK is automatically included as it's the main table's hash key -> This comment is incorrect for INCLUDE projection
     ]

--- a/infrastructure/problem-generator-v2/dynamodb.tf
+++ b/infrastructure/problem-generator-v2/dynamodb.tf
@@ -9,5 +9,18 @@ resource "aws_dynamodb_table" "problems_table" {
     type = "S"
   }
 
+  attribute {
+    name = "creatorId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name               = "CreatorIdIndex"
+    hash_key           = "creatorId"
+    projection_type    = "ALL"
+    read_capacity      = 0
+    write_capacity     = 0
+  }
+
   tags = var.common_tags
 } 


### PR DESCRIPTION
이제 문제 목록 리스트를 가져옵니다.
문제 풀이 페이지에서 모든 문제 목록을 보여주며
내저장소에서는 자신이 생성한 문제 목록을 볼 수 있습니다.

아직 페이지네이션은 없으며

column을 클릭하면 sort를 정할 수 있습니다.

검색은 단순하게 구현해놨습니다(현재 가져온 목록에서 단순하게 검색)

문제를 클릭하면 문제 풀이 페이지로 이동합니다.

문제 생성 table에 약간 추가 사항이 있습니다.

- author로 given_name 표시
- creatorId로 userId 표시(cognito로 생성되는 고유값)

이에 맞추어 커뮤니티 post, comment도 동일하게 userId로 구분, author로 UI에 표시하도록 수정하였습니다. 이제 사용자 구분이 용이해졌습니다.

해당 코드는 terraform으로 배포되서 테스트하였고 front page도 build 확인하였습니다.

frontend는 직접 실행(frontend에서 npm run dev)하시면 바로 변경사항을 확인할 수 있습니다.

문제 제출 페이지는 제출기가 작동하기 시작하면 추가할 예정입니다.

UI/UX 피드백 환영합니다.